### PR TITLE
docs: update names for consistency

### DIFF
--- a/website/src/content/docs/concepts/molecules.md
+++ b/website/src/content/docs/concepts/molecules.md
@@ -46,7 +46,7 @@ Molecules don't just have to return one thing. For example, if you're using `jot
 import { molecule } from "bunshi";
 import { atom } from "jotai";
 
-export const FormAtom = molecule((mol, scope) => {
+export const FormAtom = molecule(() => {
   const dataAtom = atom({});
   const errorsAtom = atom([]);
   const hasErrors = atom((get) => get(errorsAtom).length > 0);
@@ -80,7 +80,6 @@ import { atomWithStore } from "jotai-zustand";
 import { atomWithProxy } from "jotai-valtio";
 
 export const CountersAtom = molecule(() => {
-
   // Zustand store
   const counterStore = create(() => ({ count: 0 }));
 

--- a/website/src/content/docs/concepts/quickstart.mdx
+++ b/website/src/content/docs/concepts/quickstart.mdx
@@ -79,7 +79,7 @@ Instead, let's make each component have it's own resize observer. We can do this
 ```ts
 import { molecule, ComponentScope } from "bunshi";
 
-export const ResizeMolecule = molecule((_, scope) => {
+export const ResizeMolecule = molecule((mol, scope) => {
   scope(ComponentScope);
   return new ResizeObserver((e) => console.log("Resize", e));
 });
@@ -97,9 +97,9 @@ import { molecule, createScope } from "bunshi";
 
 export const FormScope = createScope("none");
 
-export const ResizeMolecule = molecule((,scope) => {
-    scope(FormScope);
-    return new ResizeObserver((e)=>console.log("Resize",e))
+export const ResizeMolecule = molecule((mol, scope) => {
+  scope(FormScope);
+  return new ResizeObserver((e) => console.log("Resize", e));
 });
 ```
 

--- a/website/src/content/docs/concepts/scopes.mdx
+++ b/website/src/content/docs/concepts/scopes.mdx
@@ -4,6 +4,7 @@ description: Scopes let you declaratively build graphs of molecules for differen
 sidebar:
   order: 2
 ---
+
 import { Tabs, TabItem } from "@astrojs/starlight/components";
 
 Scopes let you declaratively build graphs of molecules for different components, forms, sections, users, companies or applications and have them run in a shared environment.

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -12,8 +12,8 @@ hero:
       icon: right-arrow
       variant: primary
 ---
-import { Card, CardGrid, LinkCard } from '@astrojs/starlight/components';
- 
+
+import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
 
 Bunshi (formerly known as `jotai-molecules`) was born out of the need to create lots of state atoms for jotai, but it evolved as a general dependency injection tool
 for various state managers including [jotai](https://jotai.org/) atoms, [valtio](https://valtio.pmnd.rs/) proxies, [zustand](https://zustand-demo.pmnd.rs/) stores,
@@ -25,31 +25,33 @@ others. Stay tuned for how to use bunshi with your favorite state management lib
 ## Features
 
 <CardGrid>
-	<Card title="Small" icon="right-arrow">
-		Dependency-free and only 1.18kb minified and gzipped.
-	</Card>
-	<Card title="Flexible" icon="puzzle">
-		Works with any frontend or backed javascript framework. Ships with React and Vue integrations.
-	</Card>
-    <Card title="Tested" icon="approve-check">
-		Rigorously tested with high test coverage.
-	</Card>
-    <Card title="Efficient" icon="list-format">
-		Based on WeakMap to prevent memory leaks. Uses memoization to pevent unnecessary re-renders.
-	</Card>
+  <Card title="Small" icon="right-arrow">
+    Dependency-free and only 1.18kb minified and gzipped.
+  </Card>
+  <Card title="Flexible" icon="puzzle">
+    Works with any frontend or backed javascript framework. Ships with React and
+    Vue integrations.
+  </Card>
+  <Card title="Tested" icon="approve-check">
+    Rigorously tested with high test coverage.
+  </Card>
+  <Card title="Efficient" icon="list-format">
+    Based on WeakMap to prevent memory leaks. Uses memoization to pevent
+    unnecessary re-renders.
+  </Card>
 </CardGrid>
 
 ## Integrations
 
 <CardGrid>
-	<LinkCard
-		title="Bunshi React"
-		description="Declaratively build your jotai, valtio, zustand, nanostore and other state stores."
-		href="/integrations/react/"
-	/>
-	<LinkCard
-		title="Bunshi Vue"
-		description="Declaractively build your refs, jotai, nanostore and other state stores."
-		href="/integrations/vue/"
-	/>
+  <LinkCard
+    title="Bunshi React"
+    description="Declaratively build your jotai, valtio, zustand, nanostore and other state stores."
+    href="/integrations/react/"
+  />
+  <LinkCard
+    title="Bunshi Vue"
+    description="Declaractively build your refs, jotai, nanostore and other state stores."
+    href="/integrations/vue/"
+  />
 </CardGrid>


### PR DESCRIPTION
## Description of the change

Mostly just ran prettier and tried to clean up some call sites for `molecule` for consistency sake.

Reference: #26 