### PR TITLE
Fix typo in valtio.mdx

### DIFF
--- a/website/src/content/docs/recipes/valtio.mdx
+++ b/website/src/content/docs/recipes/valtio.mdx
@@ -104,7 +104,7 @@ You can use valtio to define global proxies shared across your application.
 ## Why Bunshi with Valtio?
 
 Bunshi helps with scoping your atoms. It allows you to pull state up and push state down the component tree.
-Valtio has a guide on how to use `usePref` and `useContext` to [create component state](https://valtio.pmnd.rs/docs/guides/component-state),
+Valtio has a guide on how to use `useRef` and `useContext` to [create component state](https://valtio.pmnd.rs/docs/guides/component-state),
 but Bunshi makes the process more simple and your code more portable.
 
 - Start using Valtio for component-level state


### PR DESCRIPTION
## Description of the change

Fixes a typo - `usePref` should be `useRef`.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation or Development tools (readme, specs, tests, code formatting)

## Links

- Jira issue number: (PUT IT HERE)
- Process.st launch checklist: (PUT IT HERE)

## Checklists

### Development

- [ ] [Prettier](https://www.npmjs.com/package/prettier) was run (if applicable)
- [ ] The behaviour changes in the pull request are covered by specs
- [ ] All tests related to the changed code pass in development

### Paperwork

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has a Jira number
- [ ] This pull request has a Process.st launch checklist

### Code review

- [ ] Changes have been reviewed by at least one other engineer
- [ ] Security impacts of this change have been considered
