### PR TITLE
When molecule returns a function, useMolecule should also return the same function

### DIFF
--- a/src/react/useMolecule.test.tsx
+++ b/src/react/useMolecule.test.tsx
@@ -25,6 +25,21 @@ export const UserMolecule = molecule((_, getScope) => {
 
 strictModeSuite(({ wrapper, isStrict }) => {
   describe("useMolecule", () => {
+    test("useMolecule returns a function returned by a molecule", () => {
+      const returnFunction = () => {};
+      const FunctionMolecule = molecule(() => {
+        return returnFunction;
+      });
+      const useFunctionMolecule = () => {
+        return {
+          molecule: useMolecule(FunctionMolecule),
+        };
+      };
+      const { result } = renderHook(useFunctionMolecule, {});
+
+      expect(result.current.molecule).toBe(returnFunction);
+    });
+
     test("Use molecule can have scope provided", () => {
       const useUserMolecule = () => {
         return {

--- a/src/react/useMolecule.tsx
+++ b/src/react/useMolecule.tsx
@@ -40,12 +40,12 @@ export function useMolecule<T>(
     ...flattenTuples(inputTuples),
   ]);
 
-  const [mutableValue, setMutableValue] = useState(value);
+  const [mutableValue, setMutableValue] = useState(() => value);
 
   useEffect(() => {
     // console.log("==== useEffect! =====");
     const subbedValue = handle.start();
-    setMutableValue(subbedValue);
+    setMutableValue(() => subbedValue);
     return () => {
       // console.log("==== CLEANUP useEffect! =====");
       handle.stop();


### PR DESCRIPTION
## Description of the change

When the return value of molecule is a function, for example, atomFamily, the return value of useMolecule is the result of the execution of that function.

This is because useState executes a function when it receives a function as an argument.

In this PR, make the argument given to useState a function whose value is wrapped as a setter.
This prevents unexpected function execution and returns the value from useMolecule as expected.

(translated by DeepL)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or Development tools (readme, specs, tests, code formatting)

## Links

- Jira issue number: (PUT IT HERE)
- Process.st launch checklist: (PUT IT HERE)

## Checklists

### Development

- [x] [Prettier](https://www.npmjs.com/package/prettier) was run (if applicable)
- [ ] The behaviour changes in the pull request are covered by specs
- [x] All tests related to the changed code pass in development

### Paperwork

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has a Jira number
- [ ] This pull request has a Process.st launch checklist

### Code review

- [ ] Changes have been reviewed by at least one other engineer
- [ ] Security impacts of this change have been considered
