### PR TITLE
Replace toSorted with array destructuring

### DIFF
--- a/src/vanilla/internal/scopeTupleSort.ts
+++ b/src/vanilla/internal/scopeTupleSort.ts
@@ -2,7 +2,7 @@ import type { AnyMoleculeScope, AnyScopeTuple } from "./internal-types";
 import { SortId } from "./symbols";
 
 export function scopeTupleSort(arr: AnyScopeTuple[]): AnyScopeTuple[] {
-  return arr.toSorted((a, b) => compareScopes(a[0], b[0]));
+  return [...arr].sort((a, b) => compareScopes(a[0], b[0]));
 }
 function compareScopes(a: AnyMoleculeScope, b: AnyMoleculeScope): number {
   return (a[SortId] as number) - (b[SortId] as number);


### PR DESCRIPTION
## Description of the change

Replace `toSorted` with array destructuring because of missing support in older browser

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or Development tools (readme, specs, tests, code formatting)

## Links

Fixes #52 

## Checklists

### Development

- [x] [Prettier](https://www.npmjs.com/package/prettier) was run (if applicable)
- [x] The behaviour changes in the pull request are covered by specs
- [ ] All tests related to the changed code pass in development

### Paperwork

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has a Jira number
- [ ] This pull request has a Process.st launch checklist

### Code review

- [ ] Changes have been reviewed by at least one other engineer
- [ ] Security impacts of this change have been considered
