### PR TITLE
Fix a typo on the landing page

### DIFF
--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -35,7 +35,7 @@ others. Stay tuned for how to use bunshi with your favorite state management lib
 		Rigorously tested with high test coverage.
 	</Card>
     <Card title="Efficient" icon="list-format">
-		Based on WeakMap to prevent memory leaks. Uses memoization to pevent unnecessary re-renders.
+		Based on WeakMap to prevent memory leaks. Uses memoization to prevent unnecessary re-renders.
 	</Card>
 </CardGrid>
 


### PR DESCRIPTION
## Description of the change

I changed the text on the landing page to say **pre**vent instead of **pe**vent.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation or Development tools (readme, specs, tests, code formatting)
