### PR TITLE
Add hierarchical dependency injection for both vanilla and React applications

### DIFF
--- a/.changeset/silly-shrimps-stare.md
+++ b/.changeset/silly-shrimps-stare.md
@@ -1,0 +1,10 @@
+---
+"bunshi": minor
+---
+
+Add `parent` property to `createInjector`. This property enables hierarchical dependency injection by allowing child injectors to inherit and override dependencies from parent injectors. This creates a tree-like structure where:
+
+- Child injectors can access and use the dependencies of their parent injectors.
+- Dependencies can be overridden at the child injector level, allowing for more granular control over dependency resolution.
+
+Add `MoleculeProvider` for React applications. This React component provides the implementation of a molecule interface for all molecules lower down in the React component tree. It uses the new parent-child injector hierarchy to ensure that existing molecule instances are preserved while allowing interface resolution.

--- a/src/react/MoleculeProvider.test.tsx
+++ b/src/react/MoleculeProvider.test.tsx
@@ -1,0 +1,218 @@
+import { renderHook } from "@testing-library/react";
+import React from "react";
+import { molecule, moleculeInterface } from "../vanilla";
+import { MoleculeProvider } from "./MoleculeProvider";
+import { strictModeSuite } from "./testing/strictModeSuite";
+import { useMolecule } from "./useMolecule";
+import { useInjector } from "./useInjector";
+
+// Test molecules and interfaces
+const NumberInterface = moleculeInterface<number>();
+const StringInterface = moleculeInterface<string>();
+
+const NumberMolecule = molecule(() => 42);
+const AnotherNumberMolecule = molecule(() => 100);
+const StringMolecule = molecule(() => "hello world");
+
+strictModeSuite(({ wrapper: Outer, isStrict }) => {
+  describe("MoleculeProvider", () => {
+    test("provides molecule interface implementation to children", () => {
+      const TestComponent = () => {
+        const number = useMolecule(NumberInterface);
+        return { number };
+      };
+
+      const Wrapper = ({ children }: { children: React.ReactNode }) => {
+        return (
+          <Outer>
+            <MoleculeProvider
+              interface={NumberInterface}
+              value={NumberMolecule}
+            >
+              {children}
+            </MoleculeProvider>
+          </Outer>
+        );
+      };
+
+      const { result } = renderHook(TestComponent, {
+        wrapper: Wrapper,
+      });
+
+      expect(result.current.number).toBe(42);
+    });
+
+    test("provides different implementations for different interfaces", () => {
+      const TestComponent = () => {
+        const number = useMolecule(NumberInterface);
+        const string = useMolecule(StringInterface);
+        return { number, string };
+      };
+
+      const Wrapper = ({ children }: { children: React.ReactNode }) => {
+        return (
+          <Outer>
+            <MoleculeProvider
+              interface={NumberInterface}
+              value={NumberMolecule}
+            >
+              <MoleculeProvider
+                interface={StringInterface}
+                value={StringMolecule}
+              >
+                {children}
+              </MoleculeProvider>
+            </MoleculeProvider>
+          </Outer>
+        );
+      };
+
+      const { result } = renderHook(TestComponent, {
+        wrapper: Wrapper,
+      });
+
+      expect(result.current.number).toBe(42);
+      expect(result.current.string).toBe("hello world");
+    });
+
+    test("nested providers override parent implementations", () => {
+      const TestComponent = () => {
+        const number = useMolecule(NumberInterface);
+        return { number };
+      };
+
+      const Wrapper = ({ children }: { children: React.ReactNode }) => {
+        return (
+          <Outer>
+            <MoleculeProvider
+              interface={NumberInterface}
+              value={NumberMolecule}
+            >
+              <MoleculeProvider
+                interface={NumberInterface}
+                value={AnotherNumberMolecule}
+              >
+                {children}
+              </MoleculeProvider>
+            </MoleculeProvider>
+          </Outer>
+        );
+      };
+
+      const { result } = renderHook(TestComponent, {
+        wrapper: Wrapper,
+      });
+
+      expect(result.current.number).toBe(100);
+    });
+
+    test("provider without value prop should not provide interface", () => {
+      const TestComponent = () => {
+        const injector = useInjector();
+        expect(() => {
+          injector.get(NumberInterface);
+        }).toThrowError(
+          "Unbound molecule interface. Could not find a molecule.",
+        );
+      };
+
+      const Wrapper = ({ children }: { children: React.ReactNode }) => {
+        return (
+          <Outer>
+            <MoleculeProvider interface={NumberInterface}>
+              {children}
+            </MoleculeProvider>
+          </Outer>
+        );
+      };
+
+      renderHook(TestComponent, {
+        wrapper: Wrapper,
+      });
+    });
+
+    test("provides molecule interface implementation to children molecules", () => {
+      const ChildMolecule = molecule((get) => {
+        return get(NumberInterface) + 1;
+      });
+
+      const TestComponent = () => {
+        const value = useMolecule(ChildMolecule);
+        return { value };
+      };
+
+      const Wrapper = ({ children }: { children: React.ReactNode }) => {
+        return (
+          <Outer>
+            <MoleculeProvider
+              interface={NumberInterface}
+              value={NumberMolecule}
+            >
+              {children}
+            </MoleculeProvider>
+          </Outer>
+        );
+      };
+
+      const { result } = renderHook(TestComponent, {
+        wrapper: Wrapper,
+      });
+
+      expect(result.current.value).toBe(43);
+    });
+
+    test("preserves parent injector cache across multiple providers", () => {
+      let sharedMoleculeCreationCount = 0;
+      const SharedMolecule = molecule(() => {
+        sharedMoleculeCreationCount++;
+        return { id: sharedMoleculeCreationCount };
+      });
+
+      const InnerMolecule = molecule((get) => {
+        const shared = get(SharedMolecule);
+        const number = get(NumberInterface);
+        return { shared, number };
+      });
+
+      // Component outside any provider
+      const OuterComponent = () => {
+        const shared = useMolecule(SharedMolecule);
+        return <div>Outer: {shared.id}</div>;
+      };
+
+      // Component inside nested providers
+      const InnerComponent = () => {
+        const service = useMolecule(InnerMolecule);
+        return { sharedId: service.shared.id, number: service.number };
+      };
+
+      const Wrapper = ({ children }: { children: React.ReactNode }) => {
+        return (
+          <Outer>
+            <OuterComponent />
+            <MoleculeProvider
+              interface={NumberInterface}
+              value={NumberMolecule}
+            >
+              <MoleculeProvider
+                interface={StringInterface}
+                value={StringMolecule}
+              >
+                {children}
+              </MoleculeProvider>
+            </MoleculeProvider>
+          </Outer>
+        );
+      };
+
+      const { result } = renderHook(InnerComponent, {
+        wrapper: Wrapper,
+      });
+
+      // SharedMolecule should be created only once despite being used across providers
+      expect(sharedMoleculeCreationCount).toBe(1);
+      expect(result.current.sharedId).toBe(1);
+      expect(result.current.number).toBe(42);
+    });
+  });
+});

--- a/src/react/MoleculeProvider.tsx
+++ b/src/react/MoleculeProvider.tsx
@@ -1,0 +1,66 @@
+import React, { useMemo } from "react";
+import { useInjector } from "./useInjector";
+import { InjectorProvider } from "./InjectorProvider";
+import { createInjector } from "../vanilla";
+import type { Molecule, MoleculeInterface } from "../vanilla";
+
+export type MoleculeProviderProps<T> = {
+  interface: MoleculeInterface<T>;
+  value?: Molecule<T> | undefined;
+  children?: React.ReactNode;
+};
+
+/**
+ * Provides the implementation of a molecule interface for all molecules lower down in the React component tree.
+ *
+ * @param props.interface - the molecule interface to provide an implementation for
+ * @param props.value - the molecule that implements the interface
+ *
+ * @typeParam T - the type of object that will be provided by this the molecule interface
+ *
+ * @example
+ * ```tsx
+ * import { molecule, moleculeInterface } from "bunshi/vanilla";
+ * import { MoleculeProvider, useMolecule } from "bunshi/react";
+ *
+ * // Define a molecule interface and a component that uses it
+ * export const NumberMoleculeInterface = moleculeInterface<number>();
+ * function DisplayNumber() {
+ *   const number = useMolecule(NumberMoleculeInterface);
+ *   return <div>{number}</div>;
+ * }
+ *
+ * // Define a molecule that implements the interface and provides it
+ * const RandomNumberMolecule = molecule<number>(() => Math.random());
+ * function App() {
+ *   return (
+ *     <MoleculeProvider interface={NumberMoleculeInterface} value={RandomNumberMolecule}>
+ *       <DisplayNumber />
+ *     </MoleculeProvider>
+ *   );
+ * }
+ * ```
+ */
+export function MoleculeProvider<T>(
+  props: MoleculeProviderProps<T>,
+): ReturnType<React.FC> {
+  const { value, interface: moleculeInterface } = props;
+
+  const parentInjector = useInjector();
+
+  const childInjector = useMemo(() => {
+    if (value) {
+      return createInjector({
+        bindings: [[moleculeInterface, value]],
+        parent: parentInjector,
+      });
+    }
+    return parentInjector;
+  }, [value, moleculeInterface, parentInjector]);
+
+  return React.createElement(
+    InjectorProvider,
+    { value: () => childInjector },
+    props.children,
+  );
+}

--- a/src/react/ScopeProvider.tsx
+++ b/src/react/ScopeProvider.tsx
@@ -4,7 +4,7 @@ import { ComponentScope, MoleculeScope } from "../vanilla";
 import { ScopeContext } from "./contexts/ScopeContext";
 import { useScopes } from "./useScopes";
 
-export type ProviderProps<T> = {
+export type ScopeProviderProps<T> = {
   scope: MoleculeScope<T>;
   value?: T;
   /**
@@ -13,6 +13,11 @@ export type ProviderProps<T> = {
   uniqueValue?: boolean;
   children?: React.ReactNode;
 };
+
+/**
+ * @deprecated use {@link ScopeProviderProps} instead
+ */
+export type ProviderProps<T> = ScopeProviderProps<T>;
 
 /**
  * Provides scope for all molecules lower down in the React component tree.
@@ -24,7 +29,7 @@ export type ProviderProps<T> = {
  * @typeParam T - the type that should match the {@link MoleculeScope} and the value provided
  */
 export function ScopeProvider<T>(
-  props: ProviderProps<T>,
+  props: ScopeProviderProps<T>,
 ): ReturnType<React.FC> {
   const { value, scope, uniqueValue } = props;
 

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -3,7 +3,11 @@ export { type MoleculeScopeOptions } from "../shared/MoleculeScopeOptions";
 export * from "../vanilla";
 
 // Basic API
-export { ScopeProvider, type ProviderProps } from "./ScopeProvider";
+export {
+  ScopeProvider,
+  type ProviderProps,
+  type ScopeProviderProps,
+} from "./ScopeProvider";
 export { useMolecule } from "./useMolecule";
 
 // Advanced API - scopes
@@ -12,3 +16,9 @@ export { useScopes } from "./useScopes";
 // Advanced API - injectors
 export { InjectorProvider } from "./InjectorProvider";
 export { useInjector } from "./useInjector";
+
+// Advanced API - molecule interfaces provider
+export {
+  MoleculeProvider,
+  type MoleculeProviderProps,
+} from "./MoleculeProvider";

--- a/src/vanilla/injector.ts
+++ b/src/vanilla/injector.ts
@@ -17,13 +17,18 @@ import type {
 } from "./internal/internal-types";
 import type { MoleculeCacheValue } from "./internal/internal-types";
 import { scopeTupleSort } from "./internal/scopeTupleSort";
-import { GetterSymbol, Injector, TypeSymbol } from "./internal/symbols";
+import {
+  GetterSymbol,
+  Injector,
+  InjectorInternalsSymbol,
+  TypeSymbol,
+} from "./internal/symbols";
 import {
   isMolecule,
   isMoleculeInterface,
   isMoleculeScope,
 } from "./internal/utils";
-import { createDeepCache } from "./internal/weakCache";
+import { createDeepCache, type DeepCache } from "./internal/weakCache";
 import {
   onMountImpl,
   useImpl,
@@ -127,6 +132,22 @@ export type MoleculeInjector = {
 } & Record<symbol, unknown>;
 
 /**
+ * Molecule injector with access to internal methods and caches.
+ *
+ * This type is used internally and is not part of the public API and may change without warning.
+ */
+type MoleculeInjectorWithInternals = MoleculeInjector & {
+  [TypeSymbol]: typeof Injector;
+  [InjectorInternalsSymbol]: {
+    getTrueMolecule: <T>(
+      molOrIntf: MoleculeOrInterface<T>,
+    ) => MoleculeInternal<T>;
+    moleculeCache: DeepCache<AnyMolecule | AnyScopeTuple, MoleculeCacheValue>;
+    dependencyCache: WeakMap<AnyMolecule, Set<AnyMoleculeScope>>;
+  };
+};
+
+/**
  * Optional properties for creating a {@link MoleculeInjector} via {@link createInjector}
  */
 export type CreateInjectorProps = {
@@ -145,7 +166,28 @@ export type CreateInjectorProps = {
    * uses in the injector
    */
   instrumentation?: Instrumentation;
+
+  /**
+   * Parent injector to inherit molecules and cache from.
+   * When a molecule or interface is not found in this injector,
+   * it will be looked up in the parent injector.
+   * The child injector shares the parent's cache to preserve singleton behavior.
+   */
+  parent?: MoleculeInjector;
 };
+
+function getInjectorInternals(
+  injector: MoleculeInjector,
+): MoleculeInjectorWithInternals[typeof InjectorInternalsSymbol];
+function getInjectorInternals(
+  injector: MoleculeInjector | undefined,
+): MoleculeInjectorWithInternals[typeof InjectorInternalsSymbol] | undefined;
+function getInjectorInternals(
+  injector: MoleculeInjector | undefined,
+): MoleculeInjectorWithInternals[typeof InjectorInternalsSymbol] | undefined {
+  if (!injector) return undefined;
+  return (injector as MoleculeInjectorWithInternals)[InjectorInternalsSymbol];
+}
 
 function bindingsToMap(bindings?: Bindings): BindingMap {
   if (!bindings) return new Map();
@@ -183,10 +225,12 @@ export function createInjector(
    *
    *
    */
-  const moleculeCache = createDeepCache<
-    AnyMolecule | AnyScopeTuple,
-    MoleculeCacheValue
-  >();
+
+  // If we have a parent injector, share its cache for consistency
+  const parentInternals = getInjectorInternals(injectorProps.parent);
+  const moleculeCache =
+    parentInternals?.moleculeCache ??
+    createDeepCache<AnyMolecule | AnyScopeTuple, MoleculeCacheValue>();
 
   /**
    * The Dependency Cache reduces the number of times that a molecule needs
@@ -213,7 +257,7 @@ export function createInjector(
      * We only need to store the scope keys, not the scope values.
      */
     AnyMoleculeScope>
-  > = new WeakMap();
+  > = parentInternals?.dependencyCache ?? new WeakMap();
 
   const bindings = bindingsToMap(injectorProps.bindings);
 
@@ -236,6 +280,12 @@ export function createInjector(
     const bound = bindings.get(molOrIntf);
     if (bound) return bound as MoleculeInternal<T>;
     if (isMolecule(molOrIntf)) return molOrIntf as MoleculeInternal<T>;
+
+    // If not found locally and we have a parent, try the parent
+    if (injectorProps.parent) {
+      const parentInternals = getInjectorInternals(injectorProps.parent);
+      return parentInternals.getTrueMolecule(molOrIntf);
+    }
 
     throw new Error(ErrorUnboundMolecule);
   }
@@ -549,14 +599,21 @@ export function createInjector(
     return [cacheValue.value as T, { start, stop }];
   }
 
-  return {
+  const injectorInstance: MoleculeInjectorWithInternals = {
     [TypeSymbol]: Injector,
+    [InjectorInternalsSymbol]: {
+      getTrueMolecule,
+      moleculeCache,
+      dependencyCache,
+    },
     get,
     use,
     useLazily: lazyUse,
     useScopes: scoper.useScopes,
     createSubscription: scoper.createSubscription,
   };
+
+  return injectorInstance;
 }
 
 enum MoleculeSubscriptionState {

--- a/src/vanilla/internal/symbols.ts
+++ b/src/vanilla/internal/symbols.ts
@@ -1,3 +1,6 @@
+// For internals
+export const InjectorInternalsSymbol = Symbol.for("bunshi.injector.internals");
+
 // For validation
 export const TypeSymbol = Symbol.for("bunshi.molecules.type");
 export const ScopeSymbol = Symbol.for("bunshi.scope.type");

--- a/website/src/content/docs/advanced/injectors.mdx
+++ b/website/src/content/docs/advanced/injectors.mdx
@@ -12,7 +12,7 @@ Most of the time you won't need to interact with the `injector` directly. It qui
 
 The core API for injectors is `createInjector`.
 
-````ts
+```ts
 import { molecule, moleculeInterface, createInjector } from "bunshi";
 
 const NumberMolecule = moleculeInterface<number>();
@@ -21,4 +21,19 @@ const RandomNumberMolecule = molecule<number>(() => Math.random());
 const injector = createInjector({
   bindings: [[NumberMolecule, RandomNumberMolecule]],
 });
+```
+
+Injectors can inherit from parent injectors, creating a hierarchy where child injectors can access parent bindings while adding their own:
+
+```ts
+const parentInjector = createInjector({
+  bindings: [[LoggerInterface, ConsoleLoggerMolecule]]
+});
+
+const childInjector = createInjector({
+  parent: parentInjector,
+  bindings: [[DatabaseInterface, SqliteMolecule]]
+});
+
+// Child can access both DatabaseInterface (local) and LoggerInterface (from parent)
 ```

--- a/website/src/content/docs/advanced/interfaces.mdx
+++ b/website/src/content/docs/advanced/interfaces.mdx
@@ -48,9 +48,54 @@ export const RegistrationFormMolecule = molecule((mol) => {
 });
 ```
 
+## Usage with Injectors
+
+Interfaces are resolved through injectors with interface bindings. Child injectors can inherit bindings from parent injectors.
+
+### Basic Binding
+
+```ts
+const injector = createInjector({
+  bindings: [[ApiClientInterface, FetchApiClientMolecule]]
+});
+
+const apiClient = injector.get(ApiClientInterface);
+```
+
+### Parent-Child Hierarchy
+
+```ts
+const parentInjector = createInjector({
+  bindings: [[ApiClientInterface, ProductionApiClientMolecule]]
+});
+
+const childInjector = createInjector({
+  parent: parentInjector,
+  bindings: [[CacheInterface, MemoryCacheMolecule]]
+});
+
+// Child can access both ApiClientInterface (from parent) and CacheInterface (local)
+```
+
+### Testing & Environment Configuration
+
+```ts
+// Override parent bindings for testing
+const testInjector = createInjector({
+  parent: productionInjector,
+  bindings: [[ApiClientInterface, MockApiClientMolecule]]
+});
+
+// Environment-specific injectors
+const injector = isDev ? devInjector : prodInjector;
+```
+
 ## Tips
 
 - Interfaces don't specify if they are scoped or not. Write your molecules accordingly.
-- Bindings to interfaces have to be done in [injectors](/advanced/injectors).
+- Bindings to interfaces have to be done in [injectors](/advanced/injectors) using the `bindings` parameter.
+- Use parent injectors to create hierarchical configurations where child injectors inherit base bindings.
+- Child injectors can override parent bindings by providing their own implementation for the same interface.
+- Interfaces can be provided in React applications using [MoleculeProvider](/integrations/react#moleculeprovider).
 - If you have a default implementation for an interface, then just use a `molecule` instead.
 - [Scopes](/concepts/scopes) can act as a replacement for interfaces if you have a large number of implementations

--- a/website/src/content/docs/integrations/react.mdx
+++ b/website/src/content/docs/integrations/react.mdx
@@ -5,7 +5,7 @@ title: "React"
 Bunshi ships with support for React out of the box.
 
 ```ts
-import { useMolecule, ScopeProvider } from "bunshi/react";
+import { useMolecule, ScopeProvider, MoleculeProvider } from "bunshi/react";
 ```
 
 ## Basic API
@@ -76,3 +76,60 @@ const App = () => (
 
 - `scope` the `MoleculeScope` reference to provide
 - `value` a new value for that scope
+
+## Advanced API
+
+### MoleculeProvider
+
+Provides implementations for [molecule interfaces](/advanced/interfaces) throughout the React component tree, allowing you to supply concrete molecules for abstract interfaces.
+
+```tsx
+// Define interface and implementation
+const SendsEmailMolecule = moleculeInterface<{
+  sendEmail(recipient: string);
+}>();
+
+const SendGmailMolecule = molecule(() => ({
+  sendEmail: (recipient: string) => { /* ... */ },
+}));
+
+// Provide implementation
+const App = () => (
+  <MoleculeProvider interface={SendsEmailMolecule} value={SendGmailMolecule}>
+    <EmailForm />
+  </MoleculeProvider>
+);
+```
+
+#### Interface Resolution in Child Molecules
+
+Child molecules can resolve interfaces while preserving existing molecule instances:
+
+```tsx
+// Parent molecule (created once, shared everywhere)
+const CacheMolecule = molecule(() => new Map());
+
+// Molecule using interfaces
+const UserServiceMolecule = molecule((get) => {
+  const cache = get(CacheMolecule);       // Existing molecule (not re-created)
+  const db = get(DatabaseInterface);      // Resolved via provider
+  const logger = get(LoggerInterface);    // Resolved via provider
+  return {
+    async getUser(id: string) {
+      const cached = cache.get(id);
+      if (cached) return cached;
+      // ... fetch and cache
+    }
+  };
+});
+
+const App = () => (
+  <MoleculeProvider interface={DatabaseInterface} value={SqliteDatabaseMolecule}>
+    <MoleculeProvider interface={LoggerInterface} value={ConsoleLevelMolecule}>
+      <UserProfile userId="123" />
+    </MoleculeProvider>
+  </MoleculeProvider>
+);
+```
+
+Providers create child injectors that inherit the parent cache, preserving existing molecules while enabling interface resolution.


### PR DESCRIPTION
## Description of the change

closes https://github.com/saasquatch/bunshi/issues/81

### Summary

- Add `parent?: MoleculeInjector` parameter to `createInjector` enabling hierarchical dependency injection
  - Child injectors inherit `bindings` from parent while allowing local overrides
  - Child and parent injectors shares the same cache
- Add a React utility `MoleculeProvider` that provides implementations for molecule interfaces throughout the React component tree.

- Deprecate the exported `ProviderProps` in favor of `ScopeProviderProps` since `MoleculeProviderProps` also exists now.

### Tests

- Add tests covering shared cache, scoped molecules, and deep hierarchies for both `createInjector` and `MoleculeProvider`

### Documentation

- `react.mdx` : Add `MoleculeProvider` documentation with interface resolution examples
- `interfaces.mdx` : Updated with parent injector patterns for hierarchical binding
- `injectors.mdx` : Add section on parent injector usage and benefits

### Usage

Parent Injector:

```tsx
const parentInjector = createInjector({
  bindings: [[LoggerInterface, ConsoleLoggerMolecule]]
});

const childInjector = createInjector({
  parent: parentInjector,
  bindings: [[DatabaseInterface, SqliteDbMolecule]]
});
// Child can access both LoggerInterface and DatabaseInterface
```

MoleculeProvider:

```tsx
const UserService = molecule((get) => {
  const cache = get(CacheMolecule); // Preserved from parent
  const db = get(DatabaseInterface); // Resolved via provider
  return new UserService(cache, db);
});

<MoleculeProvider interface={DatabaseInterface} value={SqliteDbMolecule}>
  <UserProfile /> {/* UserService gets both cache and db */}
</MoleculeProvider>
```

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation or Development tools (readme, specs, tests, code formatting)
