### PR TITLE
Fix broken test:typings due to parent node_modules node types.

### DIFF
--- a/examples/old-typescript/package-lock.json
+++ b/examples/old-typescript/package-lock.json
@@ -14,10 +14,12 @@
       }
     },
     "../..": {
-      "version": "2.1.4",
+      "version": "2.1.5",
       "license": "MIT",
       "devDependencies": {
         "@astrojs/language-server": "^2.3.3",
+        "@changesets/changelog-github": "^0.5.0",
+        "@changesets/cli": "^2.27.3",
         "@size-limit/preset-small-lib": "^9.0.0",
         "@testing-library/react": "^14.1.2",
         "@testing-library/vue": "^8.0.1",

--- a/examples/old-typescript/tsconfig.json
+++ b/examples/old-typescript/tsconfig.json
@@ -3,7 +3,9 @@
     /* Bundler mode */
     "noEmit": true,
     "esModuleInterop": true,
-    "lib": ["ES2015"]
+    "lib": ["ES2015"],
+    /* Ignore parent's node_modules */
+    "typeRoots": ["./node_modules/@types"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Description of the change

`test:typings` was broken due to the test checking the types of `../../node_modules/@types/node/ts4.8`. Force typeRoots to be the local `node_modules` to fix it. Also bump the test dependencies to bunshi 2.1.5.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or Development tools (readme, specs, tests, code formatting)
