### PR TITLE
Add ExtractMoleculeResult type to infer result type of a molecule

### DIFF
--- a/src/vanilla/molecule.ts
+++ b/src/vanilla/molecule.ts
@@ -77,6 +77,16 @@ export type MoleculeInterface<T> = {
 export type MoleculeOrInterface<T> = MoleculeInterface<T> | Molecule<T>;
 
 /**
+ * Extract the result type of a molecule
+ *
+ * @example
+ * ```ts
+ * const MyMolecule = molecule(()=>123);
+ * type ResultType = ExtractMoleculeResult<typeof MyMolecule>; // ResultType is number
+ *  */ 
+export type ExtractMoleculeResult<T> = T extends Molecule<infer U> ? U : never 
+
+/**
  * Create a new molecule
  *
  * Molecules are the core building block of bunshi. They are functions that return a value.


### PR DESCRIPTION
## Description of the change

I just added this
```ts
// Extract the result type of a molecule
export type ExtractMoleculeResult<T> = T extends Molecule<infer U> ? U : never 
```
Thanks for your work. I use your solution for all my projects. 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or Development tools (readme, specs, tests, code formatting)
